### PR TITLE
Fix literal quotes in arguments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1894,8 +1894,8 @@ var parseLine = function (line) {
     var _a = line.split('='), name = _a[0], value = _a[1];
     var commandMatch = value.match(/\$\((.+)\)$/);
     if (commandMatch) {
-        var _b = commandMatch[1].split(' '), command = _b[0], args = _b.slice(1);
-        return { name: name, command: command, args: args.length ? args : undefined };
+        var command = commandMatch[1];
+        return { name: name, command: command };
     }
     return { name: name, value: value };
 };
@@ -1926,7 +1926,7 @@ var results = parsed.map(function (_a) {
         core.setOutput(name, attrs.value);
         return;
     }
-    return (0,exec.exec)(attrs.command, attrs.args, {
+    return (0,exec.exec)(attrs.command, [], {
         listeners: {
             stdout: function (data) {
                 core.info("Setting " + name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const results = parsed.map(({ name, ...attrs }) => {
     return;
   }
 
-  return exec(attrs.command, attrs.args, {
+  return exec(attrs.command, [], {
     listeners: {
       stdout: (data: Buffer) => {
         core.info(`Setting ${name}`);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -6,10 +6,6 @@ test('hardcoded value is detected', () => {
 test('command is detected', () => {
   expect(parseLine('VERSION=$(git describe --tags)')).toEqual({
     name: 'VERSION',
-    command: 'git',
-    args: ['describe', '--tags'],
+    command: 'git describe --tags',
   });
-});
-test('no command args means Command.args not defined', () => {
-  expect(parseLine('USER=$(whoami)').args).toBeUndefined();
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,7 +8,6 @@ export interface Hardcoded extends Variable {
 
 export interface Command extends Variable {
   command: string;
-  args?: string[];
 }
 
 export const parseLine = (line: string): Hardcoded | Command => {
@@ -16,8 +15,8 @@ export const parseLine = (line: string): Hardcoded | Command => {
   const commandMatch = value.match(/\$\((.+)\)$/);
 
   if (commandMatch) {
-    const [command, ...args] = commandMatch[1].split(' ');
-    return { name, command, args:  args.length ? args : undefined };
+    const command = commandMatch[1];
+    return { name, command };
   }
   return { name, value };
 };


### PR DESCRIPTION
Prevents quotes surrounding arguments from being treated as *literal quotes*.

I.e. `echo 'Hello World'` will now be interpreted as the command `echo` with the arg `Hello World`,
instead of the command `echo` with the args `'Hello` and `World'`.

Fixes #2
